### PR TITLE
Added support for getting video multi-labels

### DIFF
--- a/downloadcategoryids.sh
+++ b/downloadcategoryids.sh
@@ -4,6 +4,10 @@ if [ "$#" -lt 2 ]; then
 	exit 1
 fi
 
+if [ ! -f ./VideoIds.csv ]; then
+	tar xf VideoIds.tar.bz2
+fi
+
 js=".js"
 txt=".txt"
 name="${@:2}"
@@ -51,13 +55,14 @@ url1='https://storage.googleapis.com/data.yt8m.org/2/j/i/'
 cut -c1-2 category-ids/tmp$txtName > category-ids/tmp2$txtName
 
 rm -rf category-ids/$txtName
-
+rm -rf category-ids/"label_${txtName}"
 # Generate the url to fetch-youtube id in category-ids/$txtName
 exec 6<"category-ids/tmp2$txtName"
 while read -r line
 do
     read -r firstTwoChars <&6
     echo "${url1}${firstTwoChars}/${line}.js" >> category-ids/$txtName
+    grep "${line}" VideoIds.csv >> category-ids/"label_${txtName}"
 done <"category-ids/tmp${txtName}"
 exec 6<&-
 

--- a/downloadvideos.sh
+++ b/downloadvideos.sh
@@ -21,14 +21,21 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     mid=$(grep -P "\t$name \(" youtube8mcategories.txt | grep -o "\".*\"" | sed -n 's/"\(.*\)"/\1/p')
 fi
 mid=$mid$txt
+label_file="label_$mid"
+line_number=1
 
 mkdir -p videos
+mkdir -p labels
 
 if [ "$1" -eq 0 ]; then
 	while read line
 		do
 			# Use -f 22/best to download in whatever best format and quality available if not 22 i.e. mp4 720p
 			$YTDL -f best "http://www.youtube.com/watch?v=$line" -o ./videos/"$name%(title)s-%(id)s.%(ext)s"
+			video_filename=`ls ./videos | grep "$line"`
+			label_filename="${video_filename%.*}-lbl.txt"
+			sed -n "${line_number}p" category-ids/$label_file > ./labels/"$label_filename"
+			line_number=$(($line_number+1))
 		done < category-ids/$mid
 else
 	limit=$1
@@ -43,8 +50,15 @@ else
 					limit=$(($limit+1))
 				fi
 				rm -rf log.txt
+				video_filename=`ls ./videos | grep "$line"`
+				label_filename="${video_filename%.*}-lbl.txt"
+				sed -n "${line_number}p" category-ids/$label_file > ./labels/"$label_filename"
+				line_number=$(($line_number+1))
 			else
 				break
 			fi
 		done < category-ids/$mid
 fi
+
+# Cleanup
+rm ./labels/-lbl.txt


### PR DESCRIPTION
This PR supports obtaining multiple labels for the video that needs to be downloaded.
The `VideoIds.tar.bz2` contains `VideoId.csv` that has 4 columns : `video_id,class_mid,class_names,label_nums` which is a lookup table file.
